### PR TITLE
fixed circular dependency with GeometryCollection

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "build": "pnpm clean && pnpm zshy",
         "typecheck": "tsc",
         "prettiercheck": "prettier -c .",
-        "circularcheck": "madge --circular --exclude 'geometry_collection.ts' --extensions ts ./src",
+        "circularcheck": "madge --circular --extensions ts ./src",
         "checks": "pnpm typecheck && pnpm build && pnpm prettiercheck && pnpm circularcheck && pnpm test"
     },
     "devDependencies": {

--- a/src/geometry/geometry.ts
+++ b/src/geometry/geometry.ts
@@ -1,8 +1,5 @@
 import * as z from "zod";
-import {
-    GeoJSONGeometryCollectionGenericSchema,
-    GeoJSONGeometryCollectionGenericSchemaType,
-} from "./geometry_collection";
+import { GeoJSONBaseSchema, GeoJSONBaseSchemaShape } from "../base";
 import { GeoJSONLineStringGenericSchema, GeoJSONLineStringGenericSchemaType } from "./line_string";
 import { GeoJSONMultiLineStringGenericSchema, GeoJSONMultiLineStringGenericSchemaType } from "./multi_line_string";
 import { GeoJSONMultiPointGenericSchema, GeoJSONMultiPointGenericSchemaType } from "./multi_point";
@@ -15,6 +12,52 @@ import {
     GeoJSONAnyPosition,
     GeoJSONPositionSchema,
 } from "./position";
+import { GeoJSONGeometryType, GeoJSONGeometryTypeSchema } from "./type";
+import { getInvalidBBoxIssue, validBBoxForCollection } from "./validation/bbox";
+import { getInvalidGeometryCollectionDimensionIssue, validDimensionsForCollection } from "./validation/dimension";
+
+export type GeoJSONGeometryCollectionGenericSchemaType<P extends GeoJSONAnyPosition> = z.ZodObject<
+    GeoJSONBaseSchemaShape<P> & {
+        type: z.ZodLiteral<typeof GeoJSONGeometryType.GeometryCollection>;
+        coordinates: z.ZodOptional<z.ZodNever>;
+        geometry: z.ZodOptional<z.ZodNever>;
+        properties: z.ZodOptional<z.ZodNever>;
+        features: z.ZodOptional<z.ZodNever>;
+        geometries: z.ZodArray<GeoJSONGeometryGenericSchemaType<P>>;
+    }
+>;
+
+export const GeoJSONGeometryCollectionGenericSchema = <P extends GeoJSONAnyPosition>(
+    positionSchema: z.ZodType<P>,
+): GeoJSONGeometryCollectionGenericSchemaType<P> =>
+    z
+        .looseObject({
+            ...GeoJSONBaseSchema(positionSchema).shape,
+            type: z.literal(GeoJSONGeometryTypeSchema.enum.GeometryCollection),
+            coordinates: z.never({ error: "GeoJSON geometry collection cannot have a 'coordinates' key" }).optional(),
+            geometry: z.never({ error: "GeoJSON geometry collection cannot have a 'geometry' key" }).optional(),
+            properties: z.never({ error: "GeoJSON geometry collection cannot have a 'properties' key" }).optional(),
+            features: z.never({ error: "GeoJSON geometry collection cannot have a 'features' key" }).optional(),
+            // > The value of "geometries" is an array. Each element of this array is a
+            //   GeoJSON Geometry object. It is possible for this array to be empty. (RFC 7946, section 3.1.8)
+            // > To maximize interoperability, implementations SHOULD avoid nested
+            //    GeometryCollections. (RFC 7946, section 3.1.8)
+            get geometries(): z.ZodArray<GeoJSONGeometryGenericSchemaType<P>> {
+                return z.array(GeoJSONGeometryGenericSchema(positionSchema));
+            },
+        })
+        .check((ctx) => {
+            // Skip remaining checks if geometries array is empty
+            if (!ctx.value.geometries.length) {
+                return;
+            }
+            if (!validDimensionsForCollection(ctx.value)) {
+                ctx.issues.push(getInvalidGeometryCollectionDimensionIssue(ctx));
+            }
+            if (!validBBoxForCollection(ctx.value)) {
+                ctx.issues.push(getInvalidBBoxIssue(ctx));
+            }
+        });
 
 export type GeoJSONGeometryGenericSchemaType<P extends GeoJSONAnyPosition> = z.ZodDiscriminatedUnion<
     [
@@ -47,6 +90,15 @@ export type DiscriminableGeometrySchema<
     P extends GeoJSONAnyPosition,
     G extends GeoJSONGeometryGeneric<P> | null,
 > = z.ZodType<G, unknown, z.core.$ZodTypeInternals<G> & z.core.$ZodTypeDiscriminableInternals>;
+
+export const GeoJSONGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSONPositionSchema);
+export type GeoJSONGeometryCollection = z.infer<typeof GeoJSONGeometryCollectionSchema>;
+
+export const GeoJSON2DGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSON2DPositionSchema);
+export type GeoJSON2DGeometryCollection = z.infer<typeof GeoJSON2DGeometryCollectionSchema>;
+
+export const GeoJSON3DGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSON3DPositionSchema);
+export type GeoJSON3DGeometryCollection = z.infer<typeof GeoJSON3DGeometryCollectionSchema>;
 
 export const GeoJSONGeometrySchema = GeoJSONGeometryGenericSchema(GeoJSONPositionSchema);
 export type GeoJSONGeometry = z.infer<typeof GeoJSONGeometrySchema>;

--- a/src/geometry/geometry_collection.ts
+++ b/src/geometry/geometry_collection.ts
@@ -1,64 +1,10 @@
-import * as z from "zod";
-import { GeoJSONBaseSchema, GeoJSONBaseSchemaShape } from "../base";
-import { GeoJSONGeometryGenericSchema, GeoJSONGeometryGenericSchemaType } from "./geometry";
-import {
-    GeoJSON2DPositionSchema,
-    GeoJSON3DPositionSchema,
-    GeoJSONAnyPosition,
-    GeoJSONPositionSchema,
-} from "./position";
-import { GeoJSONGeometryType, GeoJSONGeometryTypeSchema } from "./type";
-import { getInvalidBBoxIssue, validBBoxForCollection } from "./validation/bbox";
-import { getInvalidGeometryCollectionDimensionIssue, validDimensionsForCollection } from "./validation/dimension";
-
-export type GeoJSONGeometryCollectionGenericSchemaType<P extends GeoJSONAnyPosition> = z.ZodObject<
-    GeoJSONBaseSchemaShape<P> & {
-        type: z.ZodLiteral<typeof GeoJSONGeometryType.GeometryCollection>;
-        coordinates: z.ZodOptional<z.ZodNever>;
-        geometry: z.ZodOptional<z.ZodNever>;
-        properties: z.ZodOptional<z.ZodNever>;
-        features: z.ZodOptional<z.ZodNever>;
-        geometries: z.ZodArray<GeoJSONGeometryGenericSchemaType<P>>;
-    }
->;
-
-export const GeoJSONGeometryCollectionGenericSchema = <P extends GeoJSONAnyPosition>(
-    positionSchema: z.ZodType<P>,
-): GeoJSONGeometryCollectionGenericSchemaType<P> =>
-    z
-        .looseObject({
-            ...GeoJSONBaseSchema(positionSchema).shape,
-            type: z.literal(GeoJSONGeometryTypeSchema.enum.GeometryCollection),
-            coordinates: z.never({ error: "GeoJSON geometry collection cannot have a 'coordinates' key" }).optional(),
-            geometry: z.never({ error: "GeoJSON geometry collection cannot have a 'geometry' key" }).optional(),
-            properties: z.never({ error: "GeoJSON geometry collection cannot have a 'properties' key" }).optional(),
-            features: z.never({ error: "GeoJSON geometry collection cannot have a 'features' key" }).optional(),
-            // > The value of "geometries" is an array. Each element of this array is a
-            //   GeoJSON Geometry object. It is possible for this array to be empty. (RFC 7946, section 3.1.8)
-            // > To maximize interoperability, implementations SHOULD avoid nested
-            //    GeometryCollections. (RFC 7946, section 3.1.8)
-            get geometries(): z.ZodArray<GeoJSONGeometryGenericSchemaType<P>> {
-                return z.array(GeoJSONGeometryGenericSchema(positionSchema));
-            },
-        })
-        .check((ctx) => {
-            // Skip remaining checks if geometries array is empty
-            if (!ctx.value.geometries.length) {
-                return;
-            }
-            if (!validDimensionsForCollection(ctx.value)) {
-                ctx.issues.push(getInvalidGeometryCollectionDimensionIssue(ctx));
-            }
-            if (!validBBoxForCollection(ctx.value)) {
-                ctx.issues.push(getInvalidBBoxIssue(ctx));
-            }
-        });
-
-export const GeoJSONGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSONPositionSchema);
-export type GeoJSONGeometryCollection = z.infer<typeof GeoJSONGeometryCollectionSchema>;
-
-export const GeoJSON2DGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSON2DPositionSchema);
-export type GeoJSON2DGeometryCollection = z.infer<typeof GeoJSON2DGeometryCollectionSchema>;
-
-export const GeoJSON3DGeometryCollectionSchema = GeoJSONGeometryCollectionGenericSchema(GeoJSON3DPositionSchema);
-export type GeoJSON3DGeometryCollection = z.infer<typeof GeoJSON3DGeometryCollectionSchema>;
+export {
+    GeoJSONGeometryCollectionGenericSchema,
+    type GeoJSONGeometryCollectionGenericSchemaType,
+    GeoJSONGeometryCollectionSchema,
+    type GeoJSONGeometryCollection,
+    GeoJSON2DGeometryCollectionSchema,
+    type GeoJSON2DGeometryCollection,
+    GeoJSON3DGeometryCollectionSchema,
+    type GeoJSON3DGeometryCollection,
+} from "./geometry";


### PR DESCRIPTION
Hello, I've moved the contents of geometry_collection.ts to geometry.ts to fix a circulary dependency that made bun crash when running a bundled code. I've tested it locally with the fix and it works great for my use case and passes all the tests.

```
Bun v1.3.9 (Linux x64 baseline)
42630 |   GeoJSONPointGenericSchema(positionSchema),
42631 |   GeoJSONLineStringGenericSchema(positionSchema),
42632 |   GeoJSONMultiPointGenericSchema(positionSchema),
42633 |   GeoJSONPolygonGenericSchema(positionSchema),
42634 |   GeoJSONMultiLineStringGenericSchema(positionSchema),
42635 |   GeoJSONGeometryCollectionGenericSchema(positionSchema)
                                                ^
TypeError: GeoJSONGeometryCollectionGenericSchema is not a function. (In 'GeoJSONGeometryCollectionGenericSchema(positionSchema)', 'GeoJSONGeometryCollectionGenericSchema' is undefined)
      at GeoJSONGeometryGenericSchema (/app/server.bundle.js:42635:41)
      at /app/server.bundle.js:42637:57
      at loadAndEvaluateModule (2:1)
````